### PR TITLE
Accept URL's that contain single quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = (str, lower = false) => {
-  const regexp = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?!&//=]*)/gi;
+  const regexp = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()'@:%_\+.~#?!&//=]*)/gi;
 
   if (typeof str !== "string") {
     throw new TypeError(


### PR DESCRIPTION
Sometimes urls can contain single quotes. For example https://api.memegen.link/images/buzz/memes/i'm_buzz.png

This PR update the regex in order to accept them.