### PR TITLE
Make the extration of URLs from Markdown more accurate

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 "use strict";
 
+
 module.exports = (str, lower = false) => {
-  const regexp = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()'@:%_\+.~#?!&//=]*)/gi;
+  // The regex matches URLs, but also URLs enclosed in either () or '', which will later be removed
+  // A URLs ending in ) or ' is valid, but unlikely the indended URL is preceeeded by a matching symbol
+  const regexp = /[(']?https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()'@:%_\+.~#?!&//=]*)/gi;
 
   if (typeof str !== "string") {
     throw new TypeError(
@@ -11,6 +14,18 @@ module.exports = (str, lower = false) => {
 
   if (str) {
     let urls = str.match(regexp);
+
+    // Remove any enclosing characters that may overlap with URL characters
+    if (urls) {
+      urls = urls.map((url) => {
+        if ((url.slice(0,1) == '\'' && url.slice(-1) == '\'') || (url.slice(0,1) == '(' && url.slice(-1) == ')')) {
+          return url.slice(1, -1);
+        } else {
+          return url;
+        }
+      });
+    };
+
     if (urls) {
       return lower ? urls.map((item) => item.toLowerCase()) : urls;
     } else {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,14 +2,17 @@ const extractUrls = require("../index.js");
 
 const str = `You can read https://github.com/huckbit/extract-urls or https://www.npmjs.com/package/extract-urls for more info`;
 const strUppercase = `YOU CAN READ HTTPS://GITHUB.COM/HUCKBIT/EXTRACT-URLS OR HTTPS://WWW.NPMJS.COM/PACKAGE/EXTRACT-URLS for more info`;
-const urlsWithSpecialChars =
-  "https://example.com/!'LkhkDA6L!VweK7hsDfl6bQoU3cDjCEg!Lsx";
+const urlsWithSpecialChars = "https://example.com/!'LkhkDA6L!VweK7hsDfl6bQoU3cDjCEg!Lsx";
+const urlsWithinMarkdown = `# extract-urls
+[![npm version](https://github.com/huckbit/extract-urls)](https://www.npmjs.com/package/extract-urls)`;
+const urlsEndingWithBracket = "https://github.com/huckbit/')";
 const numericValue = 7;
 const strWithoutUrls = "you can read a book";
 const expected = [
   "https://github.com/huckbit/extract-urls",
   "https://www.npmjs.com/package/extract-urls",
 ];
+const urlsEndingWithBracketExpected = ["https://github.com/huckbit/')"];
 const urlsWithSpecialCharsExpected = [
   "https://example.com/!'LkhkDA6L!VweK7hsDfl6bQoU3cDjCEg!Lsx",
 ];
@@ -35,6 +38,18 @@ test("String containing no urls to return undefined", () => {
 test("Matching url containing special characters", () => {
   expect(extractUrls(urlsWithSpecialChars)).toEqual(
     expect.arrayContaining(urlsWithSpecialCharsExpected)
+  );
+});
+
+test("Match URL from Markdown sample", () => {
+  expect(extractUrls(urlsWithinMarkdown)).toEqual(
+      expect.arrayContaining(expected)
+    );
+});
+
+test("Match URL with trailing bracket", () => {
+  expect(extractUrls(urlsEndingWithBracket)).toEqual(
+    expect.arrayContaining(urlsEndingWithBracketExpected)
   );
 });
 


### PR DESCRIPTION
In source code files like Markdown or Python, URLs are often enclosed by characters such as `''` or `()`. These characters are also valid within URLs.

This change looks for URLs that are enclosed by a pair of these characters, and will ignore them when extracting the URLs. For example: in the markdown `[link](https://example.com/abc)`, the trailing `)` could be valid. But, due to the presence of a preceding `(`, it's very unlikely that it should be included as part of the extracted URL.

This isn't a perfect solution, and could incorrectly remove a trailing `)`. But, this is a pragmatic choice, which makes this code much more useful for extracting URLs from source code files.